### PR TITLE
Fixed date formatting

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,7 @@
     <h1 class="article-title">{{ .Title }}</h1>
 
     {{ if eq .Section "post" }}
-    <span class="article-date">{{ .Date.Format "January 1, 2006" }}</span>
+    <span class="article-date">{{ .Date.Format "January 2, 2006" }}</span>
     {{ end }}
 
     <div class="article-content">


### PR DESCRIPTION
The default date formatting displays the month numerically where it should display the date.

According to the [Go documentation for the `time` package](https://golang.org/pkg/time/#Time.Format), the reference time is defined as Mon Jan 2 15:04:05 -0700 MST 2006.
