### PR TITLE
Change baseurl in example config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://replace-this-with-your-hugo-site.com/"
+baseurl = "https://example.org"
 languageCode = "en-us"
 title = "Lithium Theme"
 theme = "hugo-lithium-theme"


### PR DESCRIPTION
Base url domain was registered by a spammer. Changing baseurl to https://example.org.

Fixes #2
