### PR TITLE
Fix warning during hugo generation

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,7 +1,9 @@
 <nav class="nav">
   <a href="{{ .Site.BaseURL }}" class="nav-logo">
-    <img src="{{ .Site.BaseURL }}images/{{ .Site.Params.logo.url }}" width="{{
-    .Site.Params.logo.width }}" height="{{ .Site.Params.logo.height }}" alt="{{ .Site.Params.logo.alt }}">
+    <img src="{{ .Site.BaseURL }}images/{{ .Site.Params.logo.url }}" 
+         width="{{ .Site.Params.logo.width }}" 
+         height="{{ .Site.Params.logo.height }}" 
+         alt="{{ .Site.Params.logo.alt }}">
   </a>
 
   <ul class="nav-links">


### PR DESCRIPTION
Hugo generation complains about unmatches "{{" due to the way the source in nav partial is formatted. This commit fixes the warning