### PR TITLE
Fix index template output of posts

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,7 +3,7 @@
 <main class="content" role="main">
 
   <div class="archive">
-    {{ range (where .Site.Pages "Type" "post").GroupByDate "2006" }}
+    {{ range (where .Data.Pages "Type" "post").GroupByDate "2006" }}
     <h2 class="archive-title">{{ .Key }}</h2>
     {{ range .Pages }}
     <article class="archive-item">


### PR DESCRIPTION
This PR fixes an issue where the posts directory was showing up as a post in index.html.

Issue and solution was found by @Watcher7 in #11.