### PR TITLE
Support custom style sheets

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -21,6 +21,9 @@ disqusShortname = ""
 
 [params]
     description = ""
+    
+    # Specify custom CSS (paths are relative to /static
+    #custom_css = ["css/foo.css", "css/bar.css"]
 
     [params.logo]
     url = "logo.png"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,3 +29,7 @@
 
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/main.css" media="all">
 <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Merriweather:400|Lato:400,400italic,700">
+
+{{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+{{- end }}


### PR DESCRIPTION
This pull requests makes it easier for users to override CSS styles used in this theme.

Credit to [this blog post](https://discourse.gohugo.io/t/how-to-override-css-classes-with-hugo/3033/4) for the code.