### PR TITLE
Add date and title to archetype file

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,3 +1,6 @@
 +++
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
 
 +++


### PR DESCRIPTION
From Hugo 0.24 this must be provided in the archetype file
itself.

Fixes #16